### PR TITLE
[#11] Add OpenGraph Protocol Meta Tags

### DIFF
--- a/config/Type.dhall
+++ b/config/Type.dhall
@@ -3,4 +3,5 @@
 , authApiKey : Text 
 , targetDir : Text
 , fetchEveryMins : Natural
+, baseUrl : Text
 }

--- a/config/config.example.dhall
+++ b/config/config.example.dhall
@@ -3,4 +3,5 @@
 , authApiKey = "YOURZULIPAPIKEY"
 , targetDir = "./site"
 , fetchEveryMins = 15
+, baseUrl = "https://archivedomain.com"
 }


### PR DESCRIPTION
Add OpenGraph Protocol meta tags to the generated HTML. These describe
the site, streams, and topics to website's that provide rich media for
linked pages(e.g., Facebook, LinkedIn).

Streams simply display the Stream Name & Description.

Topics show the Topic Name, the Stream name, the created & modified
times, a description using the first 300 characters of the first
message, and the originals poster's avatar as an image.

A new `baseUrl` configuration value has been added, which should contain
the protocol & domain of the archive(e.g., `https://funprog.srid.ca`).
This is used to generate the `url` OGP tags, which require a full URI
instead of just a path.

Refs #11