### PR TITLE
[#16] Strip HTML From OGP Description Tags

### DIFF
--- a/zulip-archive.cabal
+++ b/zulip-archive.cabal
@@ -32,4 +32,5 @@ executable zulip-archive
         directory,
         containers,
         cryptonite,
-        dhall
+        dhall,
+        tagsoup


### PR DESCRIPTION
Modify the Main.ogpMetaTags function so that HTML tags are removed from
the `og:description` meta tags in Topic pages.

Closes #16