### PR TITLE
[#20] Use the OpenGraph Module from Rib

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ let
   # To upgrade rib, go to https://github.com/srid/rib/commits/master, select the
   # revision you would like to upgrade to and set it here. Consult rib's
   # ChangeLog.md to check any notes on API migration.
-  ribRevision = "48c0e70b1d37d73680691c2eabc721bcdad04af3";
+  ribRevision = "29e01ceb5af712190ae64259b49e13b4144b24d0";
 
   inherit (import (builtins.fetchTarball "https://github.com/hercules-ci/gitignore/archive/7415c4f.tar.gz") { }) gitignoreSource;
 in {

--- a/src/Zulip/Internal.hs
+++ b/src/Zulip/Internal.hs
@@ -1,13 +1,22 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Zulip.Internal where
 
+import Control.Monad
 import Data.Aeson
 import Data.Char (isUpper)
 import Text.Casing (fromHumps, toQuietSnake)
+import qualified Text.URI as URI
 
 fieldLabelMod :: Options
 fieldLabelMod =
   defaultOptions
     { fieldLabelModifier = toQuietSnake . fromHumps . dropWhile (not . isUpper)
     }
+
+instance FromJSON URI.URI where
+    parseJSON = parseJSON >=> either (fail . show) return . URI.mkURI
+
+instance ToJSON URI.URI where
+    toJSON = toJSON . URI.render

--- a/zulip-archive.cabal
+++ b/zulip-archive.cabal
@@ -36,4 +36,5 @@ executable zulip-archive
         cryptonite,
         dhall,
         tagsoup,
-        dependent-sum
+        dependent-sum,
+        modern-uri


### PR DESCRIPTION
Refactor the OpenGraph Protocol metatag rendering to use the new
Rib.Extra.OpenGraph module.

Change the type of the Message type's _messageAvatarUrl field from Text
to a URI. This requires adding orphan instance of the Aeson type classes
to Zulip.Internal.

Bump the Rib version to the latest master commit.

Closes #20 