### PR TITLE
Fix Zulip API Client Types

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,8 @@ on:
   #    - master
   schedule:
     - cron:  '0 0 * * *'
+  # Allow running manually
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/Zulip/Client.hs
+++ b/src/Zulip/Client.hs
@@ -90,7 +90,7 @@ data Users = Users
 
 data User = User
   { _userAvatarUrl :: Maybe Text,
-    _userId :: Int,
+    _userUserId :: Int,
     _userFullName :: Text
   }
   deriving (Eq, Show)
@@ -107,7 +107,7 @@ data ServerSettings = ServerSettings
 mkArchive :: [Stream] -> [User] -> [Message] -> [Stream]
 mkArchive streams users msgsWithoutAvatar = flip fmap streams $ \stream ->
   -- TODO: Verify that stream names are unique.
-  let avatarMap = Map.fromList $ flip mapMaybe users $ \u -> (_userId u,) <$> _userAvatarUrl u
+  let avatarMap = Map.fromList $ flip mapMaybe users $ \u -> (_userUserId u,) <$> _userAvatarUrl u
       msgs = flip fmap msgsWithoutAvatar $ \msg ->
         msg
           { _messageAvatarUrl =

--- a/src/Zulip/Client.hs
+++ b/src/Zulip/Client.hs
@@ -89,7 +89,7 @@ data Users = Users
   deriving (Eq, Show)
 
 data User = User
-  { _userAvatarUrl :: Text,
+  { _userAvatarUrl :: Maybe Text,
     _userId :: Int,
     _userFullName :: Text
   }
@@ -107,7 +107,7 @@ data ServerSettings = ServerSettings
 mkArchive :: [Stream] -> [User] -> [Message] -> [Stream]
 mkArchive streams users msgsWithoutAvatar = flip fmap streams $ \stream ->
   -- TODO: Verify that stream names are unique.
-  let avatarMap = Map.fromList $ flip fmap users $ _userId &&& _userAvatarUrl
+  let avatarMap = Map.fromList $ flip mapMaybe users $ \u -> (_userId u,) <$> _userAvatarUrl u
       msgs = flip fmap msgsWithoutAvatar $ \msg ->
         msg
           { _messageAvatarUrl =


### PR DESCRIPTION
The `User`'s `id` field changed to `user_id` & the `avatar_url` is sometimes `null`.

Couldn't get `result/bin/zulip-archive` to work locally:

```
[Rib] Unhandled exception when building <unknown>: Error when running Shake build system:
  at action, called at src/Development/Shake/Forward.hs:123:5 in shake-0.19.2-BeO5l9ITSj4Iktwsoev1Pg:Development.Shake.Forward
* Raised the exception:
<stdout>: commitBuffer: invalid argument (invalid character)
```

But `Publish` workflow succeeds in my CI - had to tweak the CI config to let me manually run it.