### PR TITLE
Add Gravatar Avatars as Fallback

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -21,7 +21,6 @@ import qualified Config
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race_)
 import Data.Some
-import Data.Digest.Pure.MD5 (md5)
 import qualified Data.Text as T
 import Data.Time
 import Data.Time.Clock.POSIX
@@ -199,15 +198,7 @@ renderPage server cfg route val = html_ [lang_ "en"] $ do
         div_ [class_ "ui comments messages"] $ do
           forM_ (_topicMessages topic) $ \msg -> do
             div_ [class_ "comment"] $ do
-              a_ [class_ "avatar"] $ do
-                case _messageAvatarUrl msg of
-                  Nothing ->
-                    case _messageSenderEmail msg of
-                        Nothing ->
-                            mempty
-                        Just email ->
-                            img_ [src_ $ "https://www.gravatar.com/avatar/" <> T.pack (show $ md5 $ encodeUtf8 email)]
-                  Just avatarUrl -> img_ [src_ $ URI.render avatarUrl]
+              a_ [class_ "avatar"] $ renderAvatar msg
               div_ [class_ "content"] $ do
                 a_ [class_ "author"] $ toHtml $ _messageSenderFullName msg
                 div_ [class_ "metadata"] $ do
@@ -220,6 +211,11 @@ renderPage server cfg route val = html_ [lang_ "en"] $ do
                   toHtmlRaw (_messageContent msg)
     renderTimestamp t =
       toHtml $ formatTime defaultTimeLocale "%F %X" $ posixSecondsToUTCTime t
+    renderAvatar :: Message -> Html ()
+    renderAvatar msg = do
+      let mbUri = _messageAvatarUrl msg <|> _messageGravatarUrl msg
+      maybe mempty (\uri -> img_ [src_ $ URI.render uri]) mbUri
+
 
 routeTitle :: Text -> Route a -> Text
 routeTitle realmName = \case

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -21,6 +21,7 @@ import qualified Config
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race_)
 import Data.Some
+import Data.Digest.Pure.MD5 (md5)
 import qualified Data.Text as T
 import Data.Time
 import Data.Time.Clock.POSIX
@@ -200,7 +201,12 @@ renderPage server cfg route val = html_ [lang_ "en"] $ do
             div_ [class_ "comment"] $ do
               a_ [class_ "avatar"] $ do
                 case _messageAvatarUrl msg of
-                  Nothing -> mempty
+                  Nothing ->
+                    case _messageSenderEmail msg of
+                        Nothing ->
+                            mempty
+                        Just email ->
+                            img_ [src_ $ "https://www.gravatar.com/avatar/" <> T.pack (show $ md5 $ encodeUtf8 email)]
                   Just avatarUrl -> img_ [src_ $ URI.render avatarUrl]
               div_ [class_ "content"] $ do
                 a_ [class_ "author"] $ toHtml $ _messageSenderFullName msg

--- a/src/Zulip/Client.hs
+++ b/src/Zulip/Client.hs
@@ -12,8 +12,10 @@ module Zulip.Client where
 
 import Data.Aeson
 import Data.Aeson.TH
+import Data.Digest.Pure.MD5 (md5)
 import qualified Data.Map.Strict as Map
 import Data.Time.Clock.POSIX
+import qualified Data.Text as T
 import Network.HTTP.Req
 import Relude hiding (Option)
 import Relude.Extra.Map (lookup)
@@ -66,7 +68,7 @@ data Message = Message
     _messageContent :: Text,
     _messageContentType :: Text,
     _messageAvatarUrl :: Maybe URI, -- API doesn't always set this.
-    _messageSenderEmail :: Maybe Text, -- Not in API; only used internally
+    _messageGravatarUrl :: Maybe URI, -- Not in API; only used internally
     _messageSenderFullName :: Text,
     _messageSenderId :: Int,
     _messageStreamId :: Maybe Int,
@@ -109,13 +111,14 @@ data ServerSettings = ServerSettings
 mkArchive :: [Stream] -> [User] -> [Message] -> [Stream]
 mkArchive streams users msgsWithoutAvatar = flip fmap streams $ \stream ->
   -- TODO: Verify that stream names are unique.
-  let avatarEmailMap = Map.fromList $ flip map users $ \u -> (_userUserId u, (_userAvatarUrl u, _userEmail u))
+  let avatarMap = Map.fromList $ flip mapMaybe users $ \u -> (_userUserId u,) <$> _userAvatarUrl u
+      emailMap = Map.fromList $ users <&> \u -> (_userUserId u, _userEmail u)
       msgs = flip fmap msgsWithoutAvatar $ \msg ->
         msg
           { _messageAvatarUrl =
-              _messageAvatarUrl msg <|> (join (fst <$> lookup (_messageSenderId msg) avatarEmailMap) >>= mkURI)
-          , _messageSenderEmail =
-              snd <$> lookup (_messageSenderId msg) avatarEmailMap
+              _messageAvatarUrl msg <|> (lookup (_messageSenderId msg) avatarMap >>= mkURI)
+          , _messageGravatarUrl =
+                _messageGravatarUrl msg <|> (lookup (_messageSenderId msg) emailMap >>= mkGravatarURI)
           }
       streamMsgs = flip filter msgs $ \msg -> _messageStreamId msg == Just (_streamStreamId stream)
       topicMsgMap = Map.fromListWith (<>) $
@@ -133,6 +136,9 @@ mkArchive streams users msgsWithoutAvatar = flip fmap streams $ \stream ->
       case reverse xs of
         msg : _ -> Just $ _messageTimestamp msg
         _ -> Nothing
+    mkGravatarURI :: Text -> Maybe URI
+    mkGravatarURI email =
+      mkURI $ "https://www.gravatar.com/avatar/" <> T.pack (show $ md5 $ encodeUtf8 email)
 
 type APIConfig scheme = (Url scheme, Option scheme)
 

--- a/zulip-archive.cabal
+++ b/zulip-archive.cabal
@@ -43,4 +43,5 @@ executable zulip-archive
         dhall,
         tagsoup,
         dependent-sum,
-        modern-uri
+        modern-uri,
+        pureMD5


### PR DESCRIPTION
Use the email of a message's sender to create a GravatarUrl profile picture, rendered if there is no AvatarUrl for the message.

Not sure if we want to specify the default image set if there's no gravatar profile picture for the given email, or include a default image in this repo that gravatar can fallback to - either option seems straightforward:
https://en.gravatar.com/site/implement/images/